### PR TITLE
Placeholders which appear after a `LIMIT` should not be quoted (DBD::mysql)

### DIFF
--- a/lib/DBIx/QueryLog.pm
+++ b/lib/DBIx/QueryLog.pm
@@ -186,13 +186,13 @@ sub _bind {
     my ($dbh, $ret, @bind) = @_;
 
     my $i = 0;
-    if ($dbh->{Driver}{Name} eq 'mysql' && $DBD::mysql::VERSION >= 2.9016) {
+    if ($dbh->{Driver}{Name} eq 'mysql') {
         my $limit_flag = 0;
         $ret =~ s{([?)])}{
             if ($1 eq '?') {
                 $limit_flag ||= do {
                     my $pos = pos $ret;
-                    substr($ret, $pos - 6, 6) =~ /\A[Ll](?:IMIT|imit) \z/ ? 1 : 0;
+                    ($pos >= 6 && substr($ret, $pos - 6, 6) =~ /\A[Ll](?:IMIT|imit) \z/) ? 1 : 0;
                 };
                 $limit_flag ? $bind[$i++] : $dbh->quote($bind[$i++]);
             }
@@ -201,7 +201,8 @@ sub _bind {
                 ')';
             }
         }eg;
-    } else {
+    }
+    else {
         $ret =~ s/\?/$dbh->quote($bind[$i++])/eg;
     }
     return $ret;

--- a/t/mysql/17_limit.t
+++ b/t/mysql/17_limit.t
@@ -20,32 +20,28 @@ my $dbh = DBI->connect(
 
 DBIx::QueryLog->begin;
 
-for my $method (qw/selectrow_array selectrow_arrayref selectall_arrayref/) {
-    subtest $method => sub {
-        my $res = capture {
-            $dbh->$method(
-                'SELECT * FROM user WHERE User = ? LIMIT ? OFFSET ?', undef, 'root', 1, 0
-            );
-        };
-
-        like $res, qr/\QSELECT * FROM user WHERE User = 'root' LIMIT 1 OFFSET 0\E/;
-        done_testing;
+{
+    my $res = capture {
+        $dbh->selectrow_hashref(
+            'SELECT * FROM user WHERE User = ? LIMIT ? OFFSET ?',
+            undef,
+            'root', 1, 0,
+        );
     };
+
+    like $res, qr/\QSELECT * FROM user WHERE User = 'root' LIMIT 1 OFFSET 0\E/;
 }
 
-for my $method (qw/selectrow_array selectrow_arrayref selectall_arrayref/) {
-    subtest $method => sub {
-        my $res = capture {
-            $dbh->$method(
-                'SELECT * FROM (SELECT * FROM user WHERE User = ? LIMIT ?) AS user WHERE User = ? LIMIT ? OFFSET ?',
-                undef,
-                'root', 1, 'root', 1, 0
-            );
-        };
-
-        like $res, qr/\QSELECT * FROM (SELECT * FROM user WHERE User = 'root' LIMIT 1) AS user WHERE User = 'root' LIMIT 1 OFFSET 0\E/;
-        done_testing;
+{
+    my $res = capture {
+        $dbh->selectrow_arrayref(
+            'SELECT * FROM (SELECT * FROM user WHERE User = ? LIMIT ?) AS user WHERE User = ? LIMIT ? OFFSET ?',
+            undef,
+            'root', 1, 'root', 1, 0,
+        );
     };
+
+    like $res, qr/\QSELECT * FROM (SELECT * FROM user WHERE User = 'root' LIMIT 1) AS user WHERE User = 'root' LIMIT 1 OFFSET 0\E/;
 }
 
 done_testing;


### PR DESCRIPTION
<pre><code>use strict;
use warnings;
use DBI;
use DBIx::QueryLog ();
my $dbh = DBI->connect('dbi:mysql:test', '', '');
DBIx::QueryLog->begin;
$dbh->do("SELECT * FROM tbl WHERE foo = ? LIMIT ? OFFSET ?", undef, 'bar', 10, 20);</code></pre>

When you run this code, the DBI with DBD::mysql actually interprets the statement as `SELECT * FROM tbl WHERE foo = 'bar' LIMIT 10 OFFSET 20` and it is executed successfully, but you see the output below:
<pre>
[Wed Feb  2 18:49:09 2011] [main] [0.000161] SELECT * FROM tbl WHERE foo = 'bar' LIMIT '10' OFFSET '20' at - line 7
</pre>

This is syntactically incorrect and therefore inconvenient to use for debugging.
I have just made a quick fix for this. Hope this helps :)

ref.
https://github.com/CaptTofu/DBD-mysql/blob/master/dbdimp.c#L594

http://blog.nekokak.org/show?guid=bCdwOkUE4BGvTPMNMSAp_g
