### PR TITLE
support explain for exclusive MySQL's function.

### DIFF
--- a/lib/DBIx/QueryLog.pm
+++ b/lib/DBIx/QueryLog.pm
@@ -243,6 +243,15 @@ sub _explain {
         SELECT
     |ixms;
 
+    return undef if $ret =~ m|
+        \s*                         # white space
+        (?:
+            SQL_CALC_FOUND_ROWS \|  # exclusive MySQL funciton
+            FOUND_ROWS\(\)
+        )
+        \s*                         # white space
+    |ixms;
+
     return sub {
         my %args = @_;
         no warnings qw(redefine prototype);

--- a/t/mysql/21_do_explain.t
+++ b/t/mysql/21_do_explain.t
@@ -95,6 +95,15 @@ subtest 'select only' => sub {
     unlike $res, qr/$regex/;
 };
 
+subtest 'select exclusive' => sub {
+    my $res = capture {
+        $dbh->do('SELECT SQL_CALC_FOUND_ROWS * FROM user');
+        $dbh->do('SELECT FOUND_ROWS()');
+    };
+
+    unlike $res, qr/$regex/;
+};
+
 DBIx::QueryLog->explain(0);
 
 unless ($ENV{DBIX_QUERYLOG_EXPLAIN}) {


### PR DESCRIPTION
DBIX_QUERYLOG_EXPLAIN = 1 時に SQL_CALC_FOUND_ROWS が入ったクエリーを発行後
EXPLAIN が付いたクエリーが発行されるため FOUND_ROWS がとれなくなっていました。
SQL_CALC_FOUND_ROWS があった際は EXPLAIN がついたクエリーを発行しないようにしました。
