### PR TITLE
Skip test if user does not install Text::ASCIITable

### DIFF
--- a/t/23_do_explain.t
+++ b/t/23_do_explain.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::Requires qw(DBD::SQLite);
+use Test::Requires qw(DBD::SQLite Text::ASCIITable);
 use Test::More;
 use t::Util;
 use DBIx::QueryLog ();


### PR DESCRIPTION
Because this test expects that 'Text::ASCIITable' is installed.
(This test is failed if user does not install Text::ASCIITable)

Please see this patch.
