### PR TITLE
skip t/pg/21_do_explain.t without Text::ASCIITable

### DIFF
--- a/t/pg/21_do_explain.t
+++ b/t/pg/21_do_explain.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::Requires qw(DBD::Pg Test::PostgreSQL);
+use Test::Requires qw(DBD::Pg Test::PostgreSQL Text::ASCIITable);
 use Test::More;
 use Test::PostgreSQL;
 use t::Util;


### PR DESCRIPTION
 Without Text::ASCIITable,  the test fails.
